### PR TITLE
WIP: Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+/init
+/tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,61 @@
+FROM alpine:edge
+
+
+ADD https://github.com/just-containers/s6-overlay/releases/download/v1.18.1.5/s6-overlay-amd64.tar.gz /tmp/
+
+RUN tar xzf /tmp/s6-overlay-amd64.tar.gz -C / \
+ && rm -rf /tmp/s6-overlay-amd64.tar.gz
+
+ENV S6_KEEP_ENV=1 \
+    S6_CMD_WAIT_FOR_SERVICES=1
+
+
+COPY Makefile smf-spf.c /tmp/src/
+
+RUN echo "@community http://dl-cdn.alpinelinux.org/alpine/edge/community" \
+      >> /etc/apk/repositories \
+
+ # Upgrade existing packages & install runtime dependencies
+ && apk update \
+ && apk upgrade \
+ && apk add --no-cache \
+        libspf2 libmilter@community \
+
+ # Build smf-spf binary
+ && apk add --no-cache --virtual .build-deps \
+        build-base \
+        libspf2-dev libmilter-dev@community \
+ && cd /tmp/src \
+ && make smf-spf \
+ && mv smf-spf /usr/local/bin/ \
+
+ # Clean up unnecessary stuff
+ && apk del .build-deps \
+ && rm -rf /tmp/src \
+           /var/cache/apk/*
+
+
+COPY docker/rootfs /
+
+COPY smf-spf.conf /etc/smfs/
+
+COPY LICENSE COPYING readme README.md /usr/share/doc/smf-spf/
+
+RUN chmod +x /etc/services.d/*/run \
+
+ # Prepare default configuration
+ && sed -i -r 's/^#?Daemonize\s.*$/Daemonize off/g' /etc/smfs/smf-spf.conf \
+ && sed -i -r 's/^#?User\s.*$/User nobody/g'        /etc/smfs/smf-spf.conf \
+ && sed -i -r 's/^#?Socket\s.*$/Socket inet:8890/g' /etc/smfs/smf-spf.conf \
+
+ # Prepare directory for unix socket
+ && mkdir -p /var/run/smfs \
+ && chown -R nobody:nobody /var/run/smfs
+
+
+EXPOSE 8890
+
+
+ENTRYPOINT ["/init"]
+
+CMD ["smf-spf"]

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+VERSION ?= 2.3
+
 CC = gcc
 PREFIX = /usr/local
 SBINDIR = $(PREFIX)/sbin
@@ -51,3 +53,55 @@ install:
 	cp -p smf-spf.conf $(CONFDIR)/smf-spf.conf.new; \
 	fi
 	@echo Please, inspect and edit the $(CONFDIR)/smf-spf.conf file.
+
+
+
+
+#
+# Making Docker stuff.
+#
+
+DOCKER_IMAGE_NAME := smf-spf/smf-spf
+DOCKER_TAGS := $(VERSION),latest
+
+
+# Helper definitions
+comma := ,
+empty :=
+space := $(empty) $(empty)
+eq = $(if $(or $(1),$(2)),$(and $(findstring $(1),$(2)),\
+                                $(findstring $(2),$(1))),1)
+
+
+
+# Build Docker image.
+#
+# Usage:
+#	make docker-image [no-cache=(yes|no)] [VERSION=]
+
+no-cache ?= no
+no-cache-arg = $(if $(call eq, $(no-cache), yes), --no-cache, $(empty))
+
+docker-image:
+	docker build -t $(DOCKER_IMAGE_NAME):$(VERSION) ./
+
+
+
+# Tag Docker image with given tags.
+#
+# Usage:
+#	make docker-tags [VERSION=] [DOCKER_TAGS=t1,t2,...]
+
+tags:
+	$(foreach tag, $(subst $(comma), $(space), $(DOCKER_TAGS)), \
+		docker tag $(DOCKER_IMAGE_NAME):$(VERSION) $(IMAGE_NAME):$(tag) ;)
+
+
+# Manually push Docker images to Docker Hub.
+#
+# Usage:
+#	make docker-push [DOCKER_TAGS=t1,t2,...]
+
+docker-push:
+	$(foreach tag, $(subst $(comma), $(space), $(DOCKER_TAGS)), \
+		docker push $(DOCKER_IMAGE_NAME):$(tag) ;)

--- a/docker/rootfs/etc/cont-init.d/10-merge-smf-spf-conf
+++ b/docker/rootfs/etc/cont-init.d/10-merge-smf-spf-conf
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+
+SMFSPF_DROPINS_DIR=${SMFSPF_DROPINS_DIR:=/etc/smfs}
+SMFSPF_CONF_FILE=${SMFSPF_CONF_FILE:=/etc/mail/smfs/smf-spf.conf}
+
+
+write_cfg_file() {
+    echo -e "\n\n#\n# $1\n#\n" >> $SMFSPF_CONF_FILE
+    cat $1                     >> $SMFSPF_CONF_FILE
+}
+
+
+write_cfg_file $SMFSPF_DROPINS_DIR/smf-spf.conf
+
+[ ! -d $SMFSPF_DROPINS_DIR/conf.d ] && exit 0
+for f in `find $SMFSPF_DROPINS_DIR/conf.d -type f | sort`; do
+    write_cfg_file $f
+done

--- a/docker/rootfs/etc/fix-attrs.d/01-cont-init-finish-jobs
+++ b/docker/rootfs/etc/fix-attrs.d/01-cont-init-finish-jobs
@@ -1,0 +1,2 @@
+/etc/cont-init.d    true root 0755 0755
+/etc/cont-finish.d  true root 0755 0755

--- a/docker/rootfs/etc/mail/smfs/smf-spf.conf
+++ b/docker/rootfs/etc/mail/smfs/smf-spf.conf
@@ -1,0 +1,3 @@
+## DO NOT EDIT - GENERATED AUTOMATICALLY
+# This file represents a concatenation of all smf-spf config files contained
+# in directory /etc/smfs/conf.d and /etc/smfs/smf-spf.conf .

--- a/docker/rootfs/etc/services.d/syslog/run
+++ b/docker/rootfs/etc/services.d/syslog/run
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec syslogd -n

--- a/docker/rootfs/etc/syslog.conf
+++ b/docker/rootfs/etc/syslog.conf
@@ -1,0 +1,2 @@
+# Log anything to Docker log.
+*.*         -/dev/stdout


### PR DESCRIPTION
This is a proposed implementation of `smf-spf` Docker image discussed in #23.

### Features

- `alpine` image is used for result image to be small.
- [`s6-overlay`](https://github.com/just-containers/s6-overlay) is used as supervisor for supervising `syslogd` that is required for capturing logs of `smf-spf`.
- `nobody` user is used to run `smf-spf`, as it's already present in image.
- implements ability to specify configuration drop-ins in `/etc/smfs/conf.d/` directory.
- listening on `inet:8890` by default, but this can be reconfigured to listen unix sockets in `/var/run/smfs/` mounted directory.

### To discuss

- [ ] `VERSION` in `Makefile`. Should it be set statically, or fetched from Git tags automatically (pros/cons)?

### TODO

- [x] `Dockerfile`
- [x] `make` aliases for manual image building/tagging/pushing
- [ ] tests & upd Travic CI matrix
- [ ] [`post_push` Docker Hub hook](http://windsock.io/automated-docker-image-builds-with-multiple-tags) generation for automated builds on GitHub
- [ ] describe Docker stuff in `README.md`