### PR TITLE
Allow Received-SPF header back.

### DIFF
--- a/smf-spf.conf
+++ b/smf-spf.conf
@@ -68,7 +68,15 @@ WhitelistIP	192.168.0.0/16
 #
 #Tag		[SPF:fail]
 
-# Build a standard Received-SPF: header
+# Add the deprecated Received-SPF: header
+#
+# Default: off
+#
+# AddReceivedHeader off
+
+
+
+# Build a standard Authentication-Results: header
 #
 # Default: on
 #


### PR DESCRIPTION
By request in #31 .
Also spamassassin check if this header is present and reuses the evaluation. 