### PR TITLE
Reject messages with an empty sender

### DIFF
--- a/smf-spf-tests-refuse.conf
+++ b/smf-spf-tests-refuse.conf
@@ -1,6 +1,7 @@
 WhitelistIP	127.0.0.0/8
 RefuseFail	on	# (on|off)
 RefuseSPFnone	on	# (on|off)
+RefuseSPFNoneHelo on
 SoftFail       off      # (on|off)
 AcceptTempError off 
 TagSubject	of	# (on|off)

--- a/smf-spf.c
+++ b/smf-spf.c
@@ -788,7 +788,7 @@ static sfsistat smf_envfrom(SMFICTX *ctx, char **args) {
     SPF_request_set_env_from(spf_request, context->sender);
     if (SPF_request_query_mailfrom(spf_request, &spf_response)) {
 	syslog(LOG_INFO, "SPF none: ip=%s, fqdn=%s, helo=%s, from=%s", context->addr, context->fqdn, context->helo, context->from);
-    if (status == SPF_RESULT_NONE) {
+    if ((status == SPF_RESULT_NONE) || (status == SPF_RESULT_INVALID)) {
             if (conf.refuse_none && !strstr(context->from, "<>")) {
                     char reject[2 * MAXLINE];
                     snprintf(reject, sizeof(reject), "Sorry, we only accept mail from SPF enabled domains", context->sender);

--- a/smf-spf.c
+++ b/smf-spf.c
@@ -52,6 +52,7 @@
 #define SPF_TTL			3600
 #define REFUSE_FAIL		1
 #define REFUSE_NONE		0
+#define REFUSE_NONE_HELO		0
 #define SOFT_FAIL		0
 #define ACCEPT_PERMERR		1
 #define TAG_SUBJECT		1
@@ -135,6 +136,7 @@ typedef struct config {
     STR *tos;
     int refuse_fail;
     int refuse_none;
+    int refuse_none_helo;
     int soft_fail;
     int accept_temperror;
     int tag_subject;
@@ -375,6 +377,7 @@ static int load_config(void) {
     conf.syslog_facility = SYSLOG_FACILITY;
     conf.refuse_fail = REFUSE_FAIL;
     conf.refuse_none = REFUSE_NONE;
+    conf.refuse_none_helo = REFUSE_NONE_HELO;
     conf.soft_fail = SOFT_FAIL;
     conf.accept_temperror = ACCEPT_PERMERR;
     conf.tag_subject = TAG_SUBJECT;
@@ -474,6 +477,10 @@ static int load_config(void) {
 	}
 	if (!strcasecmp(key, "refusespfnone") && !strcasecmp(val, "on")) {
 	    conf.refuse_none = 1;
+	    continue;
+	}
+	if (!strcasecmp(key, "refusespfnonehelo") && !strcasecmp(val, "on")) {
+	    conf.refuse_none_helo = 1;
 	    continue;
 	}
 	if (!strcasecmp(key, "refusefail") && !strcasecmp(val, "off")) {
@@ -781,14 +788,25 @@ static sfsistat smf_envfrom(SMFICTX *ctx, char **args) {
     SPF_request_set_env_from(spf_request, context->sender);
     if (SPF_request_query_mailfrom(spf_request, &spf_response)) {
 	syslog(LOG_INFO, "SPF none: ip=%s, fqdn=%s, helo=%s, from=%s", context->addr, context->fqdn, context->helo, context->from);
-    if (status == SPF_RESULT_NONE && conf.refuse_none && !strstr(context->from, "<>")) {
-            char reject[2 * MAXLINE];
-            snprintf(reject, sizeof(reject), "Sorry, we only accept mail from SPF enabled domains", context->sender);
-            if (spf_response) SPF_response_free(spf_response);
-            if (spf_request) SPF_request_free(spf_request);
-            if (spf_server) SPF_server_free(spf_server);
-            smfi_setreply(ctx, "550" , "5.7.1", reject);
-            return SMFIS_REJECT;
+    if (status == SPF_RESULT_NONE) {
+            if (conf.refuse_none && !strstr(context->from, "<>")) {
+                    char reject[2 * MAXLINE];
+                    snprintf(reject, sizeof(reject), "Sorry, we only accept mail from SPF enabled domains", context->sender);
+                    if (spf_response) SPF_response_free(spf_response);
+                    if (spf_request) SPF_request_free(spf_request);
+                    if (spf_server) SPF_server_free(spf_server);
+                    smfi_setreply(ctx, "550" , "5.7.1", reject);
+                    return SMFIS_REJECT;
+            }
+            if (conf.refuse_none_helo && strstr(context->from, "<>")) {
+                    char reject[2 * MAXLINE];
+                    snprintf(reject, sizeof(reject), "Sorry, we only accept empty senders from enabled servers (HELO identity)", context->sender);
+                    if (spf_response) SPF_response_free(spf_response);
+                    if (spf_request) SPF_request_free(spf_request);
+                    if (spf_server) SPF_server_free(spf_server);
+                    smfi_setreply(ctx, "550" , "5.7.1", reject);
+                    return SMFIS_REJECT;
+            }
     }
 	if (cache && conf.spf_ttl) {
 	    mutex_lock(&cache_mutex);

--- a/smf-spf.conf
+++ b/smf-spf.conf
@@ -43,6 +43,14 @@ WhitelistIP	192.168.0.0/16
 #
 #RefuseSPFNone      off      # (on|off)
 
+# Refuse e-Mail messages when there is an empty sender
+# and there isn't an SPF policy fro the server name
+# Server name is the HELO identity
+#
+# Default: off
+#
+#RefuseSPFNoneHelo      off      # (on|off)
+
 # Refuse e-Mail messages at SPF Fail results (RFC-4408)
 #
 # Default: on

--- a/tests/04-fulltest-refusenonehelo.lua
+++ b/tests/04-fulltest-refusenonehelo.lua
@@ -1,0 +1,42 @@
+-- Copyright (c) 2009-2013, The Trusted Domain Project.  All rights reserved.
+mt.echo("SPF pass  test")
+
+-- try to start the filter
+mt.startfilter("./smf-spf", "-f", "-c","./smf-spf-tests-refuse.conf")
+
+-- try to connect to it
+conn = mt.connect("inet:2424@127.0.0.1", 40, 0.25)
+if conn == nil then
+	error("mt.connect() failed")
+end
+
+-- send connection information
+-- mt.negotiate() is called implicitly
+mt.macro(conn, SMFIC_CONNECT, "j", "mta.name.local")
+if mt.conninfo(conn, "localhost", "192.0.0.1") ~= nil then
+	error("mt.conninfo() failed")
+end
+if mt.getreply(conn) ~= SMFIR_CONTINUE then
+	error("mt.conninfo() unexpected reply")
+end
+
+if mt.helo(conn, "nospf.underspell.com") ~= nil then
+  error("mt.helo() failed")
+end
+if mt.getreply(conn) ~= SMFIR_CONTINUE then
+  error("mt.helo() unexpected reply")
+end
+
+-- send envelope macros and sender data
+mt.macro(conn, SMFIC_MAIL, "i", "t-verify-spfnonehelo")
+if mt.mailfrom(conn, "<>") ~= nil then
+	error("mt.mailfrom() failed")
+end
+
+if mt.getreply(conn) ~= SMFIR_REPLYCODE then
+	        error("mt.mailfrom() unexpected reply")
+end
+
+print ("received SMFIR_REJECT ")
+
+mt.disconnect(conn)


### PR DESCRIPTION
Reject messages with an empty sender and no SPF policy on the HELO identity.