### PR TITLE
specfile and patches for building on Fedora and CentOS Linux

### DIFF
--- a/fedora-centos-systemd/README.rpm
+++ b/fedora-centos-systemd/README.rpm
@@ -1,0 +1,57 @@
+=================================
+Quick guide to installing smf-spf
+=================================
+
+Make sure you have the following RPMs installed:
+1. sendmail    (your MTA)
+2. sendmail-cf (needed to reconfigure sendmail)
+3. libspf2     (library supporting smf-spf)
+4. smf-spf     (the milter itself)
+
+Configuring smf-spf
+===================
+
+The configuration file is /etc/mail/smfs/smf-spf.conf
+
+Start the milter using `service smf-spf start'.
+
+To ensure that the milter starts on every reboot, use `chkconfig smf-spf on'.
+
+Configuring sendmail
+====================
+
+You need to tweak the sendmail.mc file in /etc/mail
+
+If you are using sendmail 8.12.x compiled without -D_FFR_MILTER_PERDAEMON
+(this is the case with the stock Red Hat/Fedora sendmails), then the SPF
+checks will be done on all of your daemons, including the MSA daemon. This
+shouldn't be a problem, but is a bit wasteful as message submission via
+the MSA should always be authenticated, in which case no SPF checks need
+be done at all.
+
+Add the following to your sendmail.mc (before any MAILER lines):
+
+define(`confMILTER_MACROS_HELO', confMILTER_MACROS_HELO`, {verify}')dnl
+INPUT_MAIL_FILTER(`smf-spf', `S=unix:/run/smfs/smf-spf.sock, F=T, T=S:30s;R:1m')dnl
+DAEMON_OPTIONS(`Port=smtp, Name=MTA')dnl
+DAEMON_OPTIONS(`Port=submission, Name=MSA, M=Ea')dnl
+
+This gives you MTA and MSA (auth required, port 587) daemons, both using spfmilter.
+
+If your version of sendmail is compiled with -D_FFR_MILTER_PERDAEMON or you
+are using sendmail 8.13.x or later then you can limit the milter to run only
+on the MTA daemon:
+
+FEATURE(`no_default_msa')dnl
+MAIL_FILTER(`smf-spf', `S=unix:/run/smfs/smf-spf.sock, F=T, T=S:30s;R:1m')dnl
+DAEMON_OPTIONS(`Port=smtp, Name=MTA, InputMailFilters=smf-spf')dnl
+DAEMON_OPTIONS(`Port=submission, Name=MSA, M=Ea')dnl
+
+Note: the `F=T,' part of the MAIL_FILTER causes incoming connections to be tempfailed (4xx)
+if the milter is not available. If this parameter is omitted and the milter is unavailable,
+sendmail will behave as if no filter is defined.
+
+Having made these changes to sendmail.mc, use `make' to generate a new sendmail.cf.
+Then use `service sendmail reload' to have sendmail use the new configuration and start
+using smf-spf.
+

--- a/fedora-centos-systemd/smf-spf-2.4.3-Makefile.patch
+++ b/fedora-centos-systemd/smf-spf-2.4.3-Makefile.patch
@@ -1,0 +1,24 @@
+diff -ru smf-spf-2.4.3.orig/Makefile smf-spf-2.4.3/Makefile
+--- smf-spf-2.4.3.orig/Makefile	2020-03-26 00:45:26.000000000 +0100
++++ smf-spf-2.4.3/Makefile	2020-06-15 11:03:57.339000000 +0200
+@@ -7,10 +7,10 @@
+ CONFDIR = /etc/mail/smfs
+ USER = smfs
+ GROUP = smfs
+-CFLAGS = -O2 -D_REENTRANT -fomit-frame-pointer -I/usr/local/include 
++CFLAGS = -pthread $(OPTFLAGS)
+ 
+ # Linux
+-LDFLAGS = -lmilter -lpthread -L/usr/lib/libmilter -L/usr/local/lib -lspf2
++LDFLAGS = -lmilter -lpthread -lspf2
+ 
+ # FreeBSD
+ #LDFLAGS = -lmilter -pthread -L/usr/local/lib -lspf2
+@@ -25,7 +25,6 @@
+ 
+ smf-spf: smf-spf.o
+ 	$(CC) -o smf-spf smf-spf.o $(LDFLAGS)
+-	strip smf-spf
+ 
+ smf-spf.o: smf-spf.c
+ 	$(CC) $(CFLAGS) -c smf-spf.c

--- a/fedora-centos-systemd/smf-spf-2.4.3-conf.patch
+++ b/fedora-centos-systemd/smf-spf-2.4.3-conf.patch
@@ -1,0 +1,10 @@
+--- smf-spf-2.4.3.orig/smf-spf.conf	2020-03-26 00:45:26.000000000 +0100
++++ smf-spf-2.4.3/smf-spf.conf	2020-06-15 11:06:03.445000000 +0200
+@@ -82,6 +82,7 @@
+ # Default: on
+ #
+ #RefuseFail	on	# (on|off)
++RefuseFail	off
+ 
+ # When refusing e-Mail messages use a 450 SMTP code
+ #

--- a/fedora-centos-systemd/smf-spf-2.4.3-rundir.patch
+++ b/fedora-centos-systemd/smf-spf-2.4.3-rundir.patch
@@ -1,0 +1,48 @@
+diff -ru --exclude Makefile smf-spf-2.4.3.orig/readme smf-spf-2.4.3/readme
+--- smf-spf-2.4.3.orig/readme	2020-03-26 00:45:26.000000000 +0100
++++ smf-spf-2.4.3/readme	2020-06-15 15:13:35.958000000 +0200
+@@ -46,10 +46,10 @@
+ 
+   Add these lines to your Sendmail configuration file (usually sendmail.mc):
+ define(`confMILTER_MACROS_HELO', confMILTER_MACROS_HELO`, {verify}')dnl
+-INPUT_MAIL_FILTER(`smf-spf', `S=unix:/var/run/smfs/smf-spf.sock, T=S:30s;R:1m')dnl
++INPUT_MAIL_FILTER(`smf-spf', `S=unix:/run/smfs/smf-spf.sock, T=S:30s;R:1m')dnl
+ 
+-IMPORTANT: make sure that /var/run is not a group writable directory! If so,
+-or chmod 755 /var/run, or if it's impossible switch to another directory.
++IMPORTANT: make sure that /run is not a group writable directory! If so,
++or chmod 755 /run, or if it's impossible switch to another directory.
+ 
+ IMPORTANT: make sure that libmilter is compiled with BROKEN_PTHREAD_SLEEP defined.
+ If this symbol is not defined, libmilter will use sleep() in signal-handler thread,
+@@ -132,4 +132,4 @@
+ http://sourceforge.net/projects/smfs/
+ http://kurmanin.info/
+ 
+-    
+\ No newline at end of file
++    
+diff -ru --exclude Makefile smf-spf-2.4.3.orig/smf-spf.c smf-spf-2.4.3/smf-spf.c
+--- smf-spf-2.4.3.orig/smf-spf.c	2020-03-26 00:45:26.000000000 +0100
++++ smf-spf-2.4.3/smf-spf.c	2020-06-15 15:16:46.184000000 +0200
+@@ -43,7 +43,7 @@
+ #include "spf2/spf.h"
+ 
+ #define CONFIG_FILE		"/etc/mail/smfs/smf-spf.conf"
+-#define WORK_SPACE		"/var/run/smfs"
++#define WORK_SPACE		"/run/smfs"
+ #define OCONN			"unix:" WORK_SPACE "/smf-spf.sock"
+ #define USER			"smfs"
+ #define TAG_STRING		"[SPF:fail]"
+diff -ru --exclude Makefile smf-spf-2.4.3.orig/smf-spf.conf smf-spf-2.4.3/smf-spf.conf
+--- smf-spf-2.4.3.orig/smf-spf.conf	2020-03-26 00:45:26.000000000 +0100
++++ smf-spf-2.4.3/smf-spf.conf	2020-06-15 15:24:23.758000000 +0200
+@@ -157,7 +157,7 @@
+ #
+ # Default: unix:/var/run/smfs/smf-spf.sock
+ #
+-#Socket		unix:/var/run/smfs/smf-spf.sock
++#Socket		unix:/run/smfs/smf-spf.sock
+ 
+ # Facility for logging via Syslog daemon
+ #

--- a/fedora-centos-systemd/smf-spf.service
+++ b/fedora-centos-systemd/smf-spf.service
@@ -1,0 +1,11 @@
+[Unit]
+Description = Sender Policy Framework milter
+After = network.target
+Before = postfix.service sendmail.service
+
+[Service]
+Type = forking
+ExecStart = /usr/sbin/smf-spf
+
+[Install]
+WantedBy = multi-user.target

--- a/fedora-centos-systemd/smf-spf.spec
+++ b/fedora-centos-systemd/smf-spf.spec
@@ -1,0 +1,182 @@
+# Do a systemd-based build from F-15; otherwise, a sysvinit-based build
+%global use_systemd %([ "(" 0%{?fedora} -gt 14 ")" -o "(" 0%{?rhel} -gt 6 ")" ] && echo 1 || echo 0)
+
+# This macro only defined by default around Fedora 10 time
+%{!?_initddir:%global _initddir %{_initrddir}}
+
+# With systemd, the run directory is /run; otherwise it's /var/run
+%if %{use_systemd}
+%global rundir /run
+%else
+%global rundir %{_localstatedir}/run
+%endif
+
+Summary:	Mail filter for Sender Policy Framework verification
+Name:		smf-spf
+Version:	2.4.3
+Release:	1%{?dist}
+License:	GPLv2+
+Group:		System Environment/Daemons
+Url:		https://github.com/jcbf/smf-spf
+Source0:	%{name}-%{version}.tar.gz
+Source1:	smf-spf.sysv
+Source2:	smf-spf.service
+Source3:	smfs.conf
+Source4:	README.rpm
+Patch0:		smf-spf-2.4.3-Makefile.patch
+Patch2:		smf-spf-2.4.3-conf.patch
+Patch5:		smf-spf-2.4.3-rundir.patch
+Requires:	sendmail >= 8.12
+BuildRequires:	sendmail-devel >= 8.12, libspf2-devel >= 1.2.5
+BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(id -nu)
+Requires(pre):	/usr/bin/getent, /usr/sbin/groupadd, /usr/sbin/useradd, /usr/sbin/usermod
+%if %{use_systemd}
+BuildRequires:	systemd-units
+Requires(post):	systemd-units
+Requires(preun): systemd-units
+Requires(postun): systemd-units
+%else
+Requires(post): /sbin/chkconfig
+Requires(preun): /sbin/chkconfig, initscripts
+Requires(postun): initscripts
+%endif
+
+%description
+smf-spf is a lightweight, fast and reliable Sendmail milter that implements the
+Sender Policy Framework technology with the help of the libspf2 library. It
+checks SPF records to make sure that e-mail messages are authorized by the
+domain that it is coming from. It's an alternative for the spfmilter,
+spf-milter, and milter-spiff milters.
+
+%prep
+%setup -q
+
+# Don't use bundled libspf2 headers, use the system ones
+rm -rf spf2
+
+# Copy in additional sources
+cp -a %{SOURCE1} %{SOURCE2} %{SOURCE3} %{SOURCE4} .
+
+# Use the distribution optimization flags and don't strip the binary,
+# so we get usable debuginfo
+%patch0 -p1
+
+# Tag failing messages by default rather than rejecting them
+%patch2 -p1
+
+# Use /run rather than /var/run with systemd
+%if %{use_systemd}
+%patch5 -p1
+%endif
+
+%build
+make %{?_smp_mflags} OPTFLAGS="%{optflags}"
+
+%install
+rm -rf %{buildroot}
+install -d -m 700 %{buildroot}%{rundir}/smfs
+install -Dp -m 755 smf-spf %{buildroot}%{_sbindir}/smf-spf
+install -Dp -m 644 smf-spf.conf %{buildroot}%{_sysconfdir}/mail/smfs/smf-spf.conf
+%if %{use_systemd}
+# Install systemd unit file and tmpfiles.d configuration for /run/smfs
+install -Dp -m 644 smf-spf.service %{buildroot}%{_unitdir}/smf-spf.service
+install -Dp -m 644 smfs.conf %{buildroot}%{_prefix}/lib/tmpfiles.d/smfs.conf
+%else
+# Install SysV initscript
+install -Dp -m 755 smf-spf.sysv %{buildroot}%{_initddir}/smf-spf
+%endif
+
+# Create dummy socket for %%ghost-ing
+: > %{buildroot}%{rundir}/smfs/smf-spf.sock
+
+%clean
+rm -rf %{buildroot}
+
+%pre
+/usr/bin/getent group smfs >/dev/null || /usr/sbin/groupadd -r smfs
+/usr/bin/getent passwd smfs >/dev/null || \
+	/usr/sbin/useradd -r -g smfs -d %{_localstatedir}/lib/smfs \
+		-s /sbin/nologin -c "Smart Sendmail Filters" smfs
+exit 0
+
+%post
+if [ $1 -eq 1 ]; then
+	# Initial installation 
+%if %{use_systemd}
+	/bin/systemctl daemon-reload &>/dev/null || :
+%else
+	/sbin/chkconfig --add smf-spf || :
+%endif
+fi
+
+%preun
+if [ $1 -eq 0 ]; then
+	# Package removal, not upgrade
+%if %{use_systemd}
+	/bin/systemctl --no-reload disable smf-spf.service &>/dev/null || :
+	/bin/systemctl stop smf-spf.service &>/dev/null || :
+%else
+	%{_initddir}/smf-spf stop &>/dev/null || :
+	/sbin/chkconfig --del smf-spf || :
+%endif
+fi
+
+%postun
+%if %{use_systemd}
+/bin/systemctl daemon-reload &>/dev/null || :
+%endif
+if [ $1 -ge 1 ]; then
+	# Package upgrade, not uninstall
+%if %{use_systemd}
+	/bin/systemctl try-restart smf-spf.service &>/dev/null || :
+%else
+	%{_initddir}/smf-spf condrestart &>/dev/null || :
+%endif
+fi
+
+%files
+%defattr(-,root,root,-)
+%doc ChangeLog COPYING readme README.rpm
+%{_sbindir}/smf-spf
+%dir %{_sysconfdir}/mail/smfs/
+%config(noreplace) %{_sysconfdir}/mail/smfs/smf-spf.conf
+%attr(0700,smfs,smfs) %dir %{rundir}/smfs/
+%ghost %{rundir}/smfs/smf-spf.sock
+%if %{use_systemd}
+%{_prefix}/lib/tmpfiles.d/smfs.conf
+%{_unitdir}/smf-spf.service
+%else
+%{_initddir}/smf-spf
+%endif
+
+%changelog
+* Mon Jun 15 2020 Jordi Sanfeliu <jordi@fibranet.cat> 2.4.3-1
+- Updated to 2.4.3.
+
+* Sun Jul 28 2013 Paul Howarth <paul@city-fan.org> 2.0.2-6
+- Systemd detection was broken in F-19 so hardcode it instead
+
+* Tue Jul  3 2012 Paul Howarth <paul@city-fan.org> 2.0.2-5
+- Move tmpfiles.d config from %%{_sysconfdir} to %%{_prefix}/lib
+- Delay start-up until after network
+
+* Thu Sep 29 2011 Paul Howarth <paul@city-fan.org> 2.0.2-4
+- Use presence of /run/lock to determine if init is systemd
+
+* Wed Jul 13 2011 Paul Howarth <paul@city-fan.org> 2.0.2-3
+- Switch to systemd configuration where appropriate
+- Nobody else likes macros for commands
+
+* Wed Jul 28 2010 Paul Howarth <paul@city-fan.org> 2.0.2-2
+- Modernize initscript and scriptlets
+- Add dist tag
+
+* Thu Jan 11 2007 Paul Howarth <paul@city-fan.org> 2.0.2-1
+- Update to 2.0.2
+- Failing mails now tagged [SPF:fail] by default instead of [SPF-FAIL]
+
+* Fri Sep 22 2006 Paul Howarth <paul@city-fan.org> 2.0.1-1
+- Update to 2.0.1
+
+* Thu Sep 21 2006 Paul Howarth <paul@city-fan.org> 2.0.0-1
+- Initial RPM build


### PR DESCRIPTION
Hello,

I've been using this beautiful tool since ages ago, but the version I have in almost all servers is still the 2.0.2. That's the latest version you can find for RPM-based systems (RHEL, Fedora and CentOS). No newer one exist, or at least I was unable to find it.

So, I thought that it would be interesting to upgrade the v2.0.2 `.spec` file to v2.4.3 keeping the same patches as Fedora mates did.

This is the list of files that came with the SRPM version 2.0.2.
```
[root@localhost SOURCES]# l
total 108
-rw-r--r--. 1 root root  2243 Sep 21  2006 README.rpm
-rw-rw-r--. 1 root root    27 Jul 13  2011 smfs.conf
-rw-rw-r--. 1 root root   622 Jul 28  2010 smf-spf-2.0.0-Makefile.patch
-rw-r--r--. 1 root root   316 Jan 11  2007 smf-spf-2.0.2-conf.patch
-rw-rw-r--. 1 root root  2649 Jul 13  2011 smf-spf-2.0.2-rundir.patch
-rw-r--r--. 1 root root 38245 Jan 10  2007 smf-spf-2.0.2.tar.gz
-rw-rw-r--. 1 root root   213 Jul  3  2012 smf-spf.service
-rw-rw-r--. 1 root root  1547 Jul 28  2010 smf-spf.sysv
```

And this is the list of files that come with the new SRPM version 2.4.3 built with the `.spec` file provided with this PR:
```
[root@localhost SOURCES]# l
total 72
-rw-r--r--. 1 root root  2235 Jun 15 15:15 README.rpm
-rw-rw-r--. 1 root root    27 Jul 13  2011 smfs.conf
-rw-r--r--. 1 root root   276 Jun 15 11:07 smf-spf-2.4.3-conf.patch
-rw-r--r--. 1 root root   704 Jun 15 11:04 smf-spf-2.4.3-Makefile.patch
-rw-r--r--. 1 root root  2045 Jun 15 15:25 smf-spf-2.4.3-rundir.patch
-rw-r--r--. 1 root root 41913 Jun  9 17:17 smf-spf-2.4.3.tar.gz
-rw-rw-r--. 1 root root   213 Jul  3  2012 smf-spf.service
-rw-rw-r--. 1 root root  1547 Jul 28  2010 smf-spf.sysv
```

I've the RPM v2.4.3 installed on a pair of mail servers and it continues working as good as it did the 2.0.2 version. Here you can see a screen shot with SPF graph:

![mail](https://user-images.githubusercontent.com/829885/84667924-3e2bde80-af23-11ea-9b5b-154761d6ed1b.png)

![spf](https://user-images.githubusercontent.com/829885/84667964-471cb000-af23-11ea-838d-2353b8d8367e.png)


Feel free to reorganize these files or move them to a more correct directory name, they are useful for those who might want to build their own RPMs based on v2.4.3.

Thanks.
